### PR TITLE
docs: mulmoterminal / mulmoclaude を GitHub へリンク

### DIFF
--- a/articles/stopped-reviewing-my-code.md
+++ b/articles/stopped-reviewing-my-code.md
@@ -44,7 +44,7 @@ publication_name: "singularity"
 
 僕は2を選びました。そして2を選ぶというのは、精神論ではなく、**「壊れたら赤くなって止まる」を積み上げる作業**でした。
 
-以下、実際に mulmoterminal / mulmoclaude で動いているものを、設定ファイルごと紹介します。
+以下、実際に [mulmoterminal](https://github.com/receptron/mulmoterminal) / [mulmoclaude](https://github.com/receptron/mulmoclaude) で動いているものを、設定ファイルごと紹介します。どちらも MIT で公開しています。
 
 ---
 
@@ -61,7 +61,7 @@ https://github.com/isamu/claude
 
 ### 正直に言うと、リポジトリ側はほとんど要りません
 
-mulmoterminal のリポジトリにも `CLAUDE.md` があります。46行の短いものですが、これは**別のエンジニアが書いたもの**で、**僕自身はほぼ使っていません**。中身の大半が、僕のグローバル側にすでに入っているからです。
+[mulmoterminal](https://github.com/receptron/mulmoterminal) のリポジトリにも `CLAUDE.md` があります。46行の短いものですが、これは**別のエンジニアが書いたもの**で、**僕自身はほぼ使っていません**。中身の大半が、僕のグローバル側にすでに入っているからです。
 
 なぜそうなるかというと、**開発スタックをほぼ揃えているから**です。
 
@@ -167,7 +167,7 @@ yarn、TypeScript、Vitest、同じ ESLint 構成、同じ CI の形、同じテ
 
 加えて `eslint-plugin-sonarjs` の **cognitive-complexity を error**（閾値15）にしています。循環的複雑度より、人間の読みにくさに近い指標です。
 
-mulmoclaude 側はもう少し厳しく、`max-lines-per-function` が **50**、`complexity` が **15** です。
+[mulmoclaude](https://github.com/receptron/mulmoclaude) 側はもう少し厳しく、`max-lines-per-function` が **50**、`complexity` が **15** です。
 
 📎 [`mulmoclaude eslint.config.mjs#L270-L282`](https://github.com/receptron/mulmoclaude/blob/7773cd70324c3c9e4be3e143fbe4c2bd83b7c46a/eslint.config.mjs#L270-L282)
 
@@ -331,7 +331,7 @@ export default [
 
 数字から出します。
 
-| | mulmoterminal | mulmoclaude |
+| | [mulmoterminal](https://github.com/receptron/mulmoterminal) | [mulmoclaude](https://github.com/receptron/mulmoclaude) |
 |---|---|---|
 | spec ファイル | **294** | **799** |
 | テストケース | **3,373** | — |


### PR DESCRIPTION
## Summary

記事内の `mulmoterminal` / `mulmoclaude` の言及を GitHub へリンクしました。**4箇所**です。

| 行 | 場所 |
|---|---|
| 47 | 前提セクションの締め（両方の**初出**）＋「どちらも MIT で公開しています」を追記 |
| 64 | ①章 mulmoterminal の初出 |
| 170 | ②章 mulmoclaude の初出 |
| 334 | テスト数の比較表ヘッダ（どちらのリポか飛べるように） |

## 意図的にリンクしなかったもの

- **繰り返しの言及**（L82 / L180 / L245 / L576 など）— 同じリンクが何度も出るとノイズになるため、**各章の初出のみ**
- **コマンド**（`npx mulmoterminal@latest` / `npm install -g mulmoterminal`）— コード表記なのでリンク不可
- 既にリンク済みの箇所（MulmoTerminal 紹介セクション・末尾のリポ一覧・📎 パーマリンク）

全部リンクしたほうがよければ言ってください。

## User Prompt

> mulmoterminal / mulmoclaude とかって github へ link にしておきたい

🤖 Generated with [Claude Code](https://claude.com/claude-code)