### PR TITLE
docs: レビュー用スキルを GitHub にリンク＋ローカル版とPR版を区別

### DIFF
--- a/articles/stopped-reviewing-my-code.md
+++ b/articles/stopped-reviewing-my-code.md
@@ -584,7 +584,7 @@ draft でも docs だけの diff でも走らせています。**「レビュー
 
 なら CI でも動くんじゃないか。そう思って Codex の API キーを設定し、ワークフローから回してみました。すると、**まあまあちゃんとレビューが返ってくる**。それで今の形になりました。
 
-（このとき手元で書いたスキルが、後で出てくる `codex-cross-review` です。**ローカル版が先にあって、CI 版は後からついてきました**）
+（この「手元で回す」用は、いま [`codex-local-review`](https://github.com/isamu/claude/blob/273144a8bf83ff5ea2b92d78ae908cdb2ab4b541/skills/codex-local-review/SKILL.md) というスキルになっています。**ローカル版が先にあって、CI 版は後からついてきました**）
 
 この体験で確信したのですが、**レビューが CI の中で、待ちなしに回ることが、とにかく重要**です。
 
@@ -628,9 +628,10 @@ AI レビューが本当に効いたのは、まずここでした。**誰かが
 
 ### そのループ自体をスキルにする
 
-とはいえ、この繰り返しを手でやると疲れます。なので**ループそのものをスキルとして書いて**あります（[公開リポジトリ](https://github.com/isamu/claude)の `skills/` 配下）。さっき出てきた「手元で試したスキル」が育ったもので、いまは2種類あります。
+とはいえ、この繰り返しを手でやると疲れます。なので**ループそのものをスキルとして書いて**あります（[公開リポジトリ](https://github.com/isamu/claude)の `skills/` 配下）。さっき出てきた「手元で試したスキル」が育ったもので、いまは**3種類**あります。どこで回すかが違います。
 
-- **[`codex-cross-review`](https://github.com/isamu/claude/blob/273144a8bf83ff5ea2b92d78ae908cdb2ab4b541/skills/codex-cross-review/SKILL.md)** — ローカルで `codex exec` を回して指摘を受け取り、こちらが評価して直し、再レビューを要求する。**最大5イテレーションの安全キャップ**付きで、イテレーションごとに状態ファイルを残します。ループが空回りしたとき、後から「何を言われて何を直したか」を追えるようにするためです
+- **[`codex-local-review`](https://github.com/isamu/claude/blob/273144a8bf83ff5ea2b92d78ae908cdb2ab4b541/skills/codex-local-review/SKILL.md)** — PR にする前に、作業ツリーや branch の diff を**ローカルで** Codex に読ませる。GitHub を往復しないので速い。「コミット前に一回見てもらう」用です
+- **[`codex-cross-review`](https://github.com/isamu/claude/blob/273144a8bf83ff5ea2b92d78ae908cdb2ab4b541/skills/codex-cross-review/SKILL.md)** — **GitHub の PR に対して** `codex exec` を回し、指摘を受け取り、こちらが評価して直し、再レビューを要求する。**最大5イテレーションの安全キャップ**付きで、イテレーションごとに状態ファイルを残します。ループが空回りしたとき、後から「何を言われて何を直したか」を追えるようにするためです
 - **[`gh-review-loop`](https://github.com/isamu/claude/blob/273144a8bf83ff5ea2b92d78ae908cdb2ab4b541/skills/gh-review-loop/SKILL.md)** — GitHub 側のボット（Codex の Actions、CodeRabbit など）が**最新コミットに**出したものを読み、直し、push し、再レビューを待つ。`gh pr view` では出てこない**インラインのスレッドまで読む**のがポイントです
 
 そして、マージ条件を明示してあります。


### PR DESCRIPTION
## Summary

`isamu/claude` の公開スキルへのリンクを整理しました。ついでに**記述の誤りを1つ修正**しています。

## ⚠️ 修正した誤り

本文で「手元で試したスキルが `codex-cross-review` です」と書いていましたが、**公開リポジトリを確認したら別物でした**。

| スキル | 実際の役割（SKILL.md の description より） |
|---|---|
| **`codex-local-review`** | PR にする前に、**作業ツリー / branch の diff** をローカルで Codex に読ませる。**GitHub 往復なし** |
| **`codex-cross-review`** | **GitHub の PR に対して** Codex と往復するループ |

「手元で回してみたら調子が良かった」に対応するのは **`codex-local-review`** のほうです。修正しました。

## 変更内容

- 「手元で回す用は、いま `codex-local-review` というスキルになっています」に修正＋リンク
- スキル一覧を **2種類 → 3種類**に（local / cross / gh-loop）。「どこで回すかが違います」と一言添えた
- `codex-cross-review` の説明を「ローカルで codex exec を回して」→「**GitHub の PR に対して** codex exec を回し」に（local 版と並ぶと紛らわしいため）

## リンクしなかったもの

`/code-review` と `/simplify`（③テスト章）は **Claude Code の組み込みコマンド**で、`isamu/claude` の `skills/` には存在しません。リンク先が無いのでそのままにしています。

## User Prompt

> codex-cross-review などの私の skill も github にリンクできるね

🤖 Generated with [Claude Code](https://claude.com/claude-code)