### PR TITLE
docs: worktree 記事の山場を、実際のスクリーンショットに差し替える

### DIFF
--- a/articles/worktree-cost-zero.md
+++ b/articles/worktree-cost-zero.md
@@ -238,13 +238,7 @@ issue 行の右端にある **▶** を押すと、こうなります。
 
 なので、削除を「閉じる」に結びつけました。worktree で動いているセルの × を押すと、閉じる前にこう聞かれます。
 
-```
-Close ⎇ mulmoterminal (fix-grid-order)
-
-Keep the worktree to reuse it later, or remove it.
-
-[ Keep worktree ]  [ Remove worktree ]  [ Cancel ]
-```
+![worktree のセルを閉じるときの確認](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/worktree-close-keep.png)
 
 **Remove worktree** を押すと、こうなります。
 
@@ -258,16 +252,11 @@ Keep the worktree to reuse it later, or remove it.
 
 そのまま消したら、作業が消えます。なので、その場合は文面が変わります。
 
-```
-Close ⎇ mulmoterminal (fix-grid-order)
+![未コミット・未 push があるときの確認](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/worktree-close-discard.png)
 
-2 unpushed commits + 5 uncommitted changes will be discarded
-if you remove the worktree.
+**2 unpushed commits + 5 uncommitted changes** と、何がどれだけ消えるかを数えて出します。ボタンのラベルも `Remove worktree` から **`Discard & remove`** に変わります。何が起きるかを、押す前にボタン自身が言うようにしました。
 
-[ Keep worktree ]  [ Discard & remove ]  [ Cancel ]
-```
-
-ボタンのラベルも `Remove worktree` から **`Discard & remove`** に変わります。何が起きるかを、押す前にボタン自身が言うようにしました。
+ヘッダーの `+2` と `●5` も同じものを指しています。**閉じようとした瞬間に初めて知る、ということにならない**ように、作業中からずっと出ています。
 
 細かいところですが、**この確認を出す瞬間に、差分を取り直しています。** 取り直している間、削除ボタンは `Checking…` になって押せません。
 


### PR DESCRIPTION
## Summary

公開済みの [worktree 記事](https://zenn.dev/singularity/articles/worktree-cost-zero)で、**一番の山場（閉じる確認ダイアログ）だけコードブロックによる文面の再現**でした。撮影して本家ガイドに入れた（[mulmoterminal#1322](https://github.com/receptron/mulmoterminal/pull/1322) マージ済み）ので、実画像に差し替えます。

| 差し替え箇所 | 画像 |
|---|---|
| 「閉じる前にこう聞かれます」 | `worktree-close-keep.png` |
| 「未コミット・未 push があるとき」 | `worktree-close-discard.png` |

画像は 5 枚 → **7 枚**に。

## 本文も 2 文だけ足しました

スクリーンショットにヘッダーの `+2` `●5` が写っているので、そこに触れています。

> ヘッダーの `+2` と `●5` も同じものを指しています。**閉じようとした瞬間に初めて知る、ということにならない**ように、作業中からずっと出ています。

再現テキストが画像になって「2 unpushed commits + 5 uncommitted changes」が本文から消えるので、その文字列も 1 文に残しました。

## スクリーンショットについて

使い捨てインスタンス（`HOME=/tmp/mt-demo`、コミット1本のデモリポ `acme-web`）で撮影。**個人のディレクトリ名は写っていません。** 端末に出るのは `/private/tmp/mt-demo/.mulmoterminal/worktrees/acme-web-82477390/…` だけで、記事で説明した置き場所の構造がそのまま見えます。

数字（`ahead=2` / `dirty=5`）は実際にその状態を作って、ダイアログに測らせたものです。

## Items to Confirm / Review

- [ ] 画像が等倍（1280×540）。端末が写るショットは `deviceScaleFactor: 2` だと xterm だけ 2 倍に焼き付くため（この知見は本家 `images/README.md` に記録済み）
- [ ] 追加した 2 文の要否
- [ ] 記事は公開済みなので、マージ即反映になります

## User Prompt

> Playwright で撮って

work in mulmoterminal-marketing

🤖 Generated with [Claude Code](https://claude.com/claude-code)