### PR TITLE
docs: Vue テンプレートの穴を埋める手順をガイドに追加

### DIFF
--- a/guides/typescript-eslint-setup.md
+++ b/guides/typescript-eslint-setup.md
@@ -229,7 +229,44 @@ export default [
 
 **全 SFC がパースできなくなります。** ルールだけのブロックに分けるのが正解です。
 
-⚠️ **`<template>` の中は、これをやっても typescript-eslint のルールが走りません。** 届くのは `<script>` までです。テンプレートに式を書きすぎず、`<script>` の computed に出してください。
+**③ `<template>` の中には、①②をやっても typescript-eslint のルールが届きません**
+
+`vue-eslint-parser` はテンプレートを**別の AST として公開**しており、typescript-eslint はそこを走査しません。届くのは `<script>` までです。
+
+**ただし埋められます。** `vue/no-restricted-syntax` がその AST を歩く唯一のルールなので、同じ禁止をセレクタとして書きます。**Vue のプロジェクトでは必ず入れてください。**
+
+```js
+{
+  files: ["**/*.vue"],
+  rules: {
+    "vue/no-restricted-syntax": [
+      "error",
+      { selector: "TSAsExpression", message: "テンプレートで as を使わない。<script> で絞って渡すこと" },
+      { selector: "TSNonNullExpression", message: "テンプレートで ! を使わない。<script> で絞って渡すこと" },
+    ],
+  },
+}
+```
+
+**入れないと、`consistent-type-assertions` を `error` にしていてもテンプレートの `as` は1件も報告されません。** `receptron/mulmoclaude` に入れたとき、`error` 運用下で **16件**が出てきました（うち6件は `v-if` が既に絞っていて不要だったもの）。
+
+直し方は、DOM のチェックを `<script>` の名前付きハンドラに移すことです。
+
+```vue
+<!-- before -->
+@input="onChange(($event.target as HTMLInputElement).value)"
+<!-- after -->
+@input="onInput"
+```
+
+```ts
+function onInput(e: Event) {
+  if (!(e.target instanceof HTMLInputElement)) return;   // 外れたら早期 return
+  onChange(e.target.value);
+}
+```
+
+⚠️ `vue/no-restricted-syntax` は**構文セレクタ**なので、埋められるのは「書き方」までです。型情報を要するルール（`no-unsafe-*` / `no-floating-promises`）はテンプレートでは依然として走りません。**テンプレートに式を書かない**方針は引き続き有効です。
 
 ### React / Solid / Preact（`.tsx`）
 
@@ -352,7 +389,20 @@ export const e8 = `${{}}`;                                    // no-base-to-stri
 
 ★は型情報が必要なので、`parserOptions` の設定なしでは反応しません。
 
-⚠️ Vue のプロジェクトでは、**同じコードを `.vue` の `<template>` に貼っても反応しません**。これは仕様なので、テンプレート内は別途注意します。
+⚠️ Vue のプロジェクトでは、**同じコードを `.vue` の `<template>` に貼っても1件も反応しません**。テンプレート用は別に貼ってください。
+
+```vue
+<script setup lang="ts">
+const m = new Map<string, { a: string }>();
+</script>
+
+<template>
+  <div>{{ m.get("y")!.a }}</div>                                   <!-- TSNonNullExpression -->
+  <input @input="f(($event.target as HTMLInputElement).value)" />  <!-- TSAsExpression -->
+</template>
+```
+
+`vue/no-restricted-syntax` が入っていれば2件とも落ちます。**落ちなければ、`consistent-type-assertions` を `error` にしていても、テンプレートは無防備です。**
 
 ---
 
@@ -376,11 +426,14 @@ export const e8 = `${{}}`;                                    // no-base-to-stri
 - [ ] `no-floating-promises` / `no-misused-promises` / `await-thenable` / `no-base-to-string`
 - [ ] テストは型情報ブロックの `ignores` に入っている
 - [ ] Vue なら**2ブロックに分かれている**
+- [ ] Vue なら **`vue/no-restricted-syntax`** が入っている（テンプレートは他の全ルールが届かない）
 - [ ] 例外はインライン disable ではなく allowlist に理由付き
 
 ### 運用
 - [ ] `yarn typecheck` が**全 tsconfig を1コマンドで**カバーしている
+- [ ] **`yarn lint` の対象に `scripts/` `config/` などのビルド系ディレクトリが入っている**（CI を動かすコードがゲートの外にいがち）
 - [ ] CI で lint と typecheck の両方が走る
+- [ ] **緑になったら、わざと壊して落ちることを確かめた**（`const x: number = "nope"` を各領域に1つずつ）
 - [ ] warn のものが「返すべきバックログ」として認識されている
 
 ---


### PR DESCRIPTION
## Summary

`guides/typescript-eslint-setup.md` の Vue の節が **「テンプレートは諦めろ」で終わっていました**。埋める方法があるので直します。

| | 前 | 後 |
|---|---|---|
| Vue の節 | ①②（2ブロック分割）まで | **③ を追加** — `vue/no-restricted-syntax` |
| 検証サンプル | `.ts` 用のみ | **`.vue` テンプレート用を追加** |
| チェックリスト | — | `vue/no-restricted-syntax` / `scripts/` を lint 対象に / **わざと壊して確かめる** |

## 根拠

`vue-eslint-parser` はテンプレートを別の AST として公開しており、typescript-eslint はそこを走査しません。**`vue/no-restricted-syntax` がその AST を歩く唯一のルール**です。

```js
"vue/no-restricted-syntax": [
  "error",
  { selector: "TSAsExpression", message: "…" },
  { selector: "TSNonNullExpression", message: "…" },
],
```

- [receptron/mulmoclaude#2734](https://github.com/receptron/mulmoclaude/pull/2734) で導入 → **`error` 運用下で16件**が出てきた（うち6件は `v-if` が既に絞っていて不要）
- [receptron/mulmoterminal#1339](https://github.com/receptron/mulmoterminal/issues/1339) — 未導入の側で1件見つけて起票。`consistent-type-assertions` が `[2, {assertionStyle:"never"}]` で効いているファイルなのに `npx eslint` が何も出さない、という再現つき

## チェックリストに足した2つ

どちらも今回の作業で実際に踏んだ穴です。

- **`yarn lint` の対象に `scripts/` `config/` が入っているか** — mulmoclaude では入っておらず、**CI がマージ可否を判断するために動かしているコード 21ファイル・92 errors** がゲートの外にいました（うち9件が禁止したはずの `as`）
- **緑になったら、わざと壊して落ちることを確かめる** — mulmoterminal の `yarn typecheck` は server と test を一切見ていませんでした。`const x: number = "nope"` を各領域に仕込んで初めて分かります

## Items to Confirm / Review

- [ ] `vue/no-restricted-syntax` を **`error` で推奨**していますが、既存プロジェクトでは `warn` から始めるほうが安全かもしれません
- [ ] 「型情報ルールはテンプレートでは依然として走らない」という但し書きを残しています（埋まるのは構文レベルまで）
- [ ] チェックリストが長くなってきたので、そろそろ分割が要るか

## User Prompt

> eslint系の対応、ようやく全部終わったっぽい。再度、投稿したissueとそれの派生を全部見て、記事を最終盤にして。結構バグあったと思うよ

work in mulmoterminal-marketing

🤖 Generated with [Claude Code](https://claude.com/claude-code)