### PR TITLE
fix: 公開済み記事の誤りを訂正 — EXDEV は名前の衝突が原因ではなかった

### DIFF
--- a/articles/claude-code-skill-distribution.md
+++ b/articles/claude-code-skill-distribution.md
@@ -264,17 +264,45 @@ yarn run cli images script.json
 
 開発者がSkillをローカルでテストする際は `yarn run cli` を使い、マーケットプレイス経由でインストールしたユーザーは `mulmocast` を使うため、両方を記載しておくことで混乱を防げます。
 
-### マーケットプレイス名とプラグイン名の衝突
+### 【訂正】EXDEV エラーは名前の衝突が原因ではありません
 
-marketplace.jsonの`name`とplugin.jsonの`name`を同じにすると、Linux環境でインストールに失敗する場合があります（EXDEVエラー）。名前は必ず異なるものにしてください。
+:::message alert
+**この節には誤りがありました。** 公開当初、「marketplace.json と plugin.json の `name` を同じにすると Linux でインストールに失敗する（EXDEV エラー）」と書いていましたが、**名前とは無関係**でした。訂正します。
+:::
 
-```json
-// marketplace.json
-{ "name": "mulmocast-plugins" }    // ← "mulmocast-plugins"
+実際の原因は [anthropics/claude-code#14799](https://github.com/anthropics/claude-code/issues/14799) にあります。
 
-// plugin.json
-{ "name": "mulmocast" }             // ← "mulmocast"（異なる名前にする）
 ```
+Error: Failed to install: EXDEV: cross-device link not permitted,
+rename '/home/user/.claude/plugins/cache/…' -> '/tmp/claude-plugin-temp-…'
+```
+
+最近の Linux ディストリビューション（Ubuntu 21.04 以降、Fedora、Arch など）では `/tmp` が **tmpfs** としてマウントされます。一方 `~/.claude` は実ディスク上にあります。**別のファイルシステムをまたぐ `fs.rename()` は失敗する**ため、インストーラがその2つの間でリネームしていたことが原因でした。
+
+つまり**名前に関係なく、あらゆるプラグインで発生**します。当時の回避策は、一時ディレクトリを同じファイルシステムに置くことでした。
+
+```bash
+export TMPDIR="$HOME/.claude/tmp"
+```
+
+そして**この問題は修正済みです**（issue は 2026年2月にクローズ）。現在の Claude Code を使っているなら、対応は不要です。
+
+なお `marketplace.json` の `name` には**2種類ある**ので、そこは混同しないでください。
+
+```jsonc
+// .claude-plugin/marketplace.json
+{
+  "name": "mulmocast-plugins",          // マーケットプレイスの名前
+  "plugins": [
+    { "name": "mulmocast", ... }        // ← plugin.json と一致させる
+  ]
+}
+
+// .claude-plugin/plugin.json
+{ "name": "mulmocast" }
+```
+
+`plugins[]` の中の名前は、**plugin.json と一致させるのが正しい**書き方です（この2つで紐づけています）。異なるべきなのは、1階層上のマーケットプレイス自身の名前です。
 
 ## まとめ
 


### PR DESCRIPTION
## Summary

**公開済み**の [Claude Code Skillの配布方法](https://zenn.dev/singularity/articles/claude-code-skill-distribution) に事実誤認がありました。訂正します。

### 何が間違っていたか

> marketplace.json の `name` と plugin.json の `name` を同じにすると、Linux 環境でインストールに失敗する場合があります（EXDEV エラー）。名前は必ず異なるものにしてください。

**名前とは無関係でした。**

### 実際の原因

[anthropics/claude-code#14799](https://github.com/anthropics/claude-code/issues/14799)

```
rename '/home/user/.claude/plugins/cache/…' -> '/tmp/claude-plugin-temp-…'
```

最近の Linux では `/tmp` が **tmpfs**、`~/.claude` は実ディスク。**別ファイルシステムをまたぐ `fs.rename()` が失敗**していたもので、インストーラがその2つの間でリネームしていたのが原因です。

- **名前に関係なく、あらゆるプラグインで発生**する
- 当時の回避策は `TMPDIR="$HOME/.claude/tmp"`
- **修正済み**（issue は 2026年2月クローズ）。現行版なら対応不要

### もう1点、誤解を招く書き方だった箇所

`marketplace.json` には `name` が**2つ**あります。

```
name: "mulmocast-plugins"        ← 異なるべきなのはこっち
plugins[0].name: "mulmocast"     ← plugin.json と一致させるのが正しい
```

「marketplace.json と plugin.json の name を同じにするな」という書き方だと、読者が **`plugins[0].name` を変えて壊す**恐れがありました。どちらを指しているか明示しています。

## 対応

`:::message alert` で**訂正であることを明示**したうえで、正しい原因・回避策・修正済みであることを書きました。元の記述を黙って差し替えるのではなく、**何が間違っていたかを残して**います。

## Items to Confirm / Review

- [ ] **訂正の見せ方**。`:::message alert` で節の冒頭に置いていますが、記事末尾に「訂正履歴」としてまとめる形もあります
- [ ] 節見出しを `### 【訂正】EXDEV エラーは名前の衝突が原因ではありません` にしました。目次に「訂正」が出ます
- [ ] すでに修正済みの問題なので、節ごと削除する選択肢もあります（ただし**誤情報を出した記録は残すべき**と判断しました）

## 経緯

英語版（dev.to 用）を書く際に codex-local-review をかけたところ、「EXDEV の因果が立証されていない」と指摘されました。ヘッジして逃げようとしたのですが、**そもそも Linux を使っていないので検証できない**ことに気づき、出典を探して誤りが判明しました。

英語版はこの発見自体を記事の柱にしています（「無料で守れるルールは、反証される機会がないまま生き残る」）。

work in mulmoterminal-marketing

🤖 Generated with [Claude Code](https://claude.com/claude-code)