### PR TITLE
docs: worktree 記事に Claude Code 本体の機能への言及を足す

### DIFF
--- a/articles/worktree-cost-zero.md
+++ b/articles/worktree-cost-zero.md
@@ -142,6 +142,26 @@ stash@{2}: WIP on feature/x: 1a2b3c4 refactor: ...
 
 ![並行するエージェント](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/grid-2x2.png)
 
+### 追記：Claude Code 本体にも worktree 機能があります
+
+**この記事を書いたあとに指摘されて気づいたので、正直に足しておきます。** Claude Code には `--worktree`（`-w`）が **v2.1.49 から**あります。
+
+```bash
+claude --worktree feature-auth        # worktree を切ってそこで起動
+claude --worktree feature-auth --tmux # tmux セッションも作る
+```
+
+[公式ドキュメント](https://code.claude.com/docs/en/worktrees)には cleanup も `.worktreeinclude`（worktree に持ち込むファイルの指定）も、大きなモノレポ向けの `worktree.sparsePaths` もあります。**1体を隔離して走らせたいだけなら、これで足ります。** 何も入れなくていい。
+
+さらに **`claude agents`**（v2.1.139、Research Preview）というセッション一覧もあります。全セッションを状態別（Working / Needs input / Completed）に並べて、Haiku が各セッションの作業内容を1行で要約してくれる。**知らなかった人はぜひ一度打ってみてください。**
+
+そのうえで、この記事の話は消えません。
+
+- **どこに作ったか・何本あるか**は、結局こちらが把握することになります。`claude agents` は**セッション**の一覧であって、worktree の一覧ではありません
+- **消すきっかけ**が要ります。作るのが1コマンドでも、消し忘れは起きます
+
+以下は「**作る・消すを、既にやっている操作に完全に埋める**」とどうなるか、という話です。本体の機能で足りる人は、それでいいと思います。
+
 ## やったこと ── コマンドを簡単にするのをやめた
 
 僕たちが作っている [MulmoTerminal](https://github.com/receptron/mulmoterminal)（Claude Code / Codex を並べて監督するブラウザ UI）で、この問題に手を付けました。


### PR DESCRIPTION
## Summary

[公開済みの worktree 記事](https://zenn.dev/singularity/articles/worktree-cost-zero)が、**Claude Code 本体の `--worktree` に一度も触れていませんでした。** 追記します。

## 事実

公式ドキュメントと changelog で確認しました。

| 機能 | 初出 | 記事公開時点で |
|---|---|---|
| `claude --worktree` / `-w` | **v2.1.49** | **すでに存在** |
| `--tmux`（worktree 用の tmux セッション） | 同上 | 同上 |
| `claude agents`（セッション一覧・AI要約・通知） | **v2.1.139**（Research Preview） | **すでに存在** |

`--worktree` には cleanup も `.worktreeinclude` も `worktree.sparsePaths` もあります。**1体を隔離して走らせたいだけなら本体で足ります。**

## 追記の方針

「**知らなかったので正直に足す**」形にしました。隠して後から指摘されるほうが弱いので。

そのうえで、記事の主張が消えないことも書いています。

- `claude agents` は**セッション**の一覧であって、**worktree の一覧ではない** → 「どこに何本あるか」は結局こちらが持つ
- **消すきっかけ**が要る。作るのが1コマンドでも消し忘れは起きる

そして「**本体の機能で足りる人は、それでいい**」と明記しました。読者に本体の機能を教えるほうが記事として誠実で、そのうえで差分を語るほうが説得力があります。

## Items to Confirm / Review

- [ ] **`claude agents` を紹介していること**。「知らなかった人はぜひ一度打ってみてください」と書いています。競合を宣伝しているとも読めますが、**知らずに tmux を6分割している読者のほうが多い**と判断しました
- [ ] 「本体で足りる人はそれでいい」と書いた点。弱腰に見えるか、誠実に見えるか
- [ ] 追記の位置（並列化の必要性を説明した直後、自分たちの実装を語る前）

## 背景

インタビュー6人と自発記事2本を数え直したところ、**`claude agents` への言及はゼロ**でした（出たのは VS Code 11回・worktree 10回・Cursor 8回・tmux 2回）。使われていないのではなく、**知られていない**という理解です。[`positioning.md`](https://github.com/receptron/mulmoterminal-marketing/blob/main/strategy/positioning.md) 側も同時に更新しています。

work in mulmoterminal-marketing

🤖 Generated with [Claude Code](https://claude.com/claude-code)