### PR TITLE
docs: what-else-was-off のタイトルを差し替える

### DIFF
--- a/articles/what-else-was-off.md
+++ b/articles/what-else-was-off.md
@@ -1,5 +1,5 @@
 ---
-title: "ESLint と TypeScript の設定、ネット記事のコピペで作っていませんか？"
+title: "strict を入れても as は止まらない ── ESLint と tsconfig の「入れたつもり」を数える"
 emoji: "📏"
 type: "tech"
 topics: ["TypeScript", "ESLint", "ClaudeCode", "AI", "vibecoding"]
@@ -7,7 +7,9 @@ published: true
 publication_name: "singularity"
 ---
 
-正直に聞きます。
+`strict` を入れているから、型まわりは一番厳しくしてあるつもりでいました。**違いました。`as` を止めるルールは `strict` に入っていません。** うちのコードには `as` が **149箇所**残っていました。
+
+その話をする前に、正直に聞きます。
 
 **あなたのプロジェクトの `tsconfig.json` と `eslint.config.js`、どこかからコピペして、そのままになっていませんか。**
 


### PR DESCRIPTION
## Summary

公開済み記事のタイトルを、検証済みの事実そのものに差し替える。本文の変更は冒頭2文のみ。

| | |
|---|---|
| Before | ESLint と TypeScript の設定、ネット記事のコピペで作っていませんか？ |
| After | strict を入れても as は止まらない ── ESLint と tsconfig の「入れたつもり」を数える |

## Items to Confirm / Review

- タイトルの事実性: typescript-eslint の `strict` プリセットに `consistent-type-assertions` は含まれず `stylistic` 側にある、という本文の検証結果をそのままタイトルにしている
- 新しいリード1文が、既存の「正直に聞きます」以降の流れを壊していないか
- slug は変えていないので既存 URL は維持される

## 根拠

公開6.5時間で 0 like / 0 コメント。publication の直近15本を実測した結果:

```
338  07/24 金 14:55  ターミナルを自作したら…生産性がバグった話
305  07/27 月 14:06  1日500コミットは、もう読めない
 54  07/19 日 00:13  AIでがんがん書く時代の「きれいなコード」の守り方
  0  08/04 火 07:22  （この記事）
```

同じ ESLint 題材で 54 取った 7/19 の記事との差はタイトルの向き。「守り方」は渡す形、「作っていませんか？」は読む前に読者を採点する形になっていた。

## User Prompt

- zenn 公開された。長文tweetを。
- 結果どう？
- ではできることはやろう