### PR TITLE
docs: type を idea から tech に統一

### DIFF
--- a/articles/issue-median-one-hour.md
+++ b/articles/issue-median-one-hour.md
@@ -1,7 +1,7 @@
 ---
 title: "ユーザーの困りごとは、その日のうちに直す ── 中央値1.2時間、最速9分"
 emoji: "⏱️"
-type: "idea"
+type: "tech"
 topics: ["ClaudeCode", "AI", "OSS", "個人開発", "vibecoding"]
 published: true
 publication_name: "singularity"

--- a/articles/name_of_instance_and_data.md
+++ b/articles/name_of_instance_and_data.md
@@ -1,7 +1,7 @@
 ---
 title: "データとインスタンスの変数名"
 emoji: "🚀"
-type: "idea"
+type: "tech"
 topics: [Node.js, naming, Tech]
 published: true
 publication_name: "singularity"

--- a/articles/small-teams-ai.md
+++ b/articles/small-teams-ai.md
@@ -1,7 +1,7 @@
 ---
 title: "AIに大きな仕様書を渡して一気に作らせるのは、宝くじを買うようなものです"
 emoji: "🍕"
-type: "idea"
+type: "tech"
 topics: ["AI", "ClaudeCode", "vibecoding", "開発プロセス", "マネジメント"]
 published: true
 publication_name: "singularity"


### PR DESCRIPTION
公開済み記事のうち `type: "idea"` だった3本を `tech` に変更。

| 記事 | |
|---|---|
| `small-teams-ai` | 今回の記事 |
| `issue-median-one-hour` | シリーズの3本目 |
| `name_of_instance_and_data` | |

これで公開済み135本すべてが `tech` になります。**今後の新規記事も `tech` で統一**します。

## User Prompt

- zenn ideaじゃなくてtechにしよう これからもぜんぶ